### PR TITLE
Relax scope of some CloudWatch logging permissions

### DIFF
--- a/docker.js
+++ b/docker.js
@@ -80,7 +80,7 @@ exports.task = function(ctx, name, {role,
                                               "ecr:DescribeImages",
                                               "ecr:BatchGetImage"]));
 
-        policyStatements.push(iam.policyStmt([logGroup.arn],
+        policyStatements.push(iam.policyStmt(["*"],
                                              ["logs:CreateLogStream",
                                               "logs:PutLogEvents"]));
 


### PR DESCRIPTION
Ran into some trouble with this; this change helped and seems mostly
harmless.